### PR TITLE
feat: add EdgeRouter X SFP (fw01) as SNMP scrape target

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -36,10 +36,7 @@ scrape_configs:
   - job_name: 'snmp_devices'
     static_configs:
       - targets:
-        # Add your SNMP-enabled devices here
-        # - firewall.local
-        # - switch.local
-        # - ap.local
+        - 192.168.0.254  # fw01 — EdgeRouter X SFP (SNMP community: public)
     metrics_path: /snmp
     params:
       module: [if_mib]


### PR DESCRIPTION
192.168.0.254 — EdgeRouter X SFP, EdgeOS 3.0.1
SNMP already enabled (community: public, confirmed in UI) Uses existing if_mib module → interface throughput, errors, uptime